### PR TITLE
Integrate Google AdMob banner and interstitial ads

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- AdMob App ID -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713"/>
     </application>
     
     <!-- Queries section - this is where the fix is needed -->

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,14 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>GADApplicationIdentifier</key>
+	<string>ca-app-pub-3940256099942544~1458002511</string>
+	<key>SKAdNetworkItems</key>
+	<array>
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>cstr6suwn9.skadnetwork</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/lib/core/services/ad_service.dart
+++ b/lib/core/services/ad_service.dart
@@ -1,0 +1,168 @@
+import 'dart:io';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+
+class AdService {
+  static final AdService _instance = AdService._internal();
+  factory AdService() => _instance;
+  AdService._internal();
+
+  InterstitialAd? _interstitialAd;
+  bool _isInterstitialAdReady = false;
+  int _numInterstitialLoadAttempts = 0;
+  static const int maxFailedLoadAttempts = 3;
+
+  // Test Ad Unit IDs - Replace with your actual AdMob IDs in production
+  static String get bannerAdUnitId {
+    if (Platform.isAndroid) {
+      return 'ca-app-pub-3940256099942544/6300978111'; // Test Banner Ad
+    } else if (Platform.isIOS) {
+      return 'ca-app-pub-3940256099942544/2934735716'; // Test Banner Ad
+    } else {
+      throw UnsupportedError('Unsupported platform');
+    }
+  }
+
+  static String get interstitialAdUnitId {
+    if (Platform.isAndroid) {
+      return 'ca-app-pub-3940256099942544/1033173712'; // Test Interstitial Ad
+    } else if (Platform.isIOS) {
+      return 'ca-app-pub-3940256099942544/4411468910'; // Test Interstitial Ad
+    } else {
+      throw UnsupportedError('Unsupported platform');
+    }
+  }
+
+  // Initialize the Mobile Ads SDK
+  static Future<void> initialize() async {
+    await MobileAds.instance.initialize();
+  }
+
+  // Create a Banner Ad Widget
+  BannerAd createBannerAd() {
+    return BannerAd(
+      adUnitId: bannerAdUnitId,
+      size: AdSize.banner,
+      request: const AdRequest(),
+      listener: BannerAdListener(
+        onAdLoaded: (ad) {
+          print('Banner ad loaded.');
+        },
+        onAdFailedToLoad: (ad, error) {
+          print('Banner ad failed to load: $error');
+          ad.dispose();
+        },
+        onAdOpened: (ad) {
+          print('Banner ad opened.');
+        },
+        onAdClosed: (ad) {
+          print('Banner ad closed.');
+        },
+      ),
+    );
+  }
+
+  // Create a large Banner Ad Widget (for item view)
+  BannerAd createLargeBannerAd() {
+    return BannerAd(
+      adUnitId: bannerAdUnitId,
+      size: AdSize.largeBanner,
+      request: const AdRequest(),
+      listener: BannerAdListener(
+        onAdLoaded: (ad) {
+          print('Large banner ad loaded.');
+        },
+        onAdFailedToLoad: (ad, error) {
+          print('Large banner ad failed to load: $error');
+          ad.dispose();
+        },
+        onAdOpened: (ad) {
+          print('Large banner ad opened.');
+        },
+        onAdClosed: (ad) {
+          print('Large banner ad closed.');
+        },
+      ),
+    );
+  }
+
+  // Load Interstitial Ad
+  void loadInterstitialAd({Function? onAdLoaded}) {
+    InterstitialAd.load(
+      adUnitId: interstitialAdUnitId,
+      request: const AdRequest(),
+      adLoadCallback: InterstitialAdLoadCallback(
+        onAdLoaded: (ad) {
+          print('Interstitial ad loaded.');
+          _interstitialAd = ad;
+          _numInterstitialLoadAttempts = 0;
+          _isInterstitialAdReady = true;
+
+          _interstitialAd!.setImmersiveMode(true);
+
+          _interstitialAd!.fullScreenContentCallback = FullScreenContentCallback(
+            onAdShowedFullScreenContent: (ad) {
+              print('Interstitial ad showed fullscreen content.');
+            },
+            onAdDismissedFullScreenContent: (ad) {
+              print('Interstitial ad dismissed.');
+              ad.dispose();
+              _isInterstitialAdReady = false;
+              // Preload next interstitial ad
+              loadInterstitialAd();
+            },
+            onAdFailedToShowFullScreenContent: (ad, error) {
+              print('Interstitial ad failed to show: $error');
+              ad.dispose();
+              _isInterstitialAdReady = false;
+              // Preload next interstitial ad
+              loadInterstitialAd();
+            },
+          );
+
+          if (onAdLoaded != null) {
+            onAdLoaded();
+          }
+        },
+        onAdFailedToLoad: (error) {
+          print('Interstitial ad failed to load: $error');
+          _numInterstitialLoadAttempts += 1;
+          _interstitialAd = null;
+          _isInterstitialAdReady = false;
+
+          if (_numInterstitialLoadAttempts < maxFailedLoadAttempts) {
+            Future.delayed(
+              Duration(seconds: _numInterstitialLoadAttempts * 2),
+              () => loadInterstitialAd(onAdLoaded: onAdLoaded),
+            );
+          }
+        },
+      ),
+    );
+  }
+
+  // Show Interstitial Ad
+  void showInterstitialAd() {
+    if (_isInterstitialAdReady && _interstitialAd != null) {
+      _interstitialAd!.show();
+    } else {
+      print('Interstitial ad is not ready yet.');
+      // Load the ad if it's not ready
+      loadInterstitialAd();
+    }
+  }
+
+  // Check if interstitial ad is ready
+  bool get isInterstitialAdReady => _isInterstitialAdReady;
+
+  // Dispose interstitial ad
+  void disposeInterstitialAd() {
+    _interstitialAd?.dispose();
+    _interstitialAd = null;
+    _isInterstitialAdReady = false;
+  }
+
+  // Dispose all ads
+  void dispose() {
+    disposeInterstitialAd();
+  }
+}

--- a/lib/features/home page/homepage.dart
+++ b/lib/features/home page/homepage.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:aswenna/data/managers/category_manager.dart';
 import 'package:aswenna/screens/sub_category_screen.dart';
 import 'package:aswenna/core/utils/color_utils.dart';
+import 'package:aswenna/core/services/ad_service.dart';
+import 'package:aswenna/widgets/banner_ad_widget.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -16,6 +18,30 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   final scaffoldKey = GlobalKey<ScaffoldState>();
+  final AdService _adService = AdService();
+  bool _hasShownInterstitial = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Load interstitial ad for home page
+    _adService.loadInterstitialAd(onAdLoaded: () {
+      // Show interstitial ad after a short delay when page opens
+      if (!_hasShownInterstitial && mounted) {
+        Future.delayed(const Duration(milliseconds: 500), () {
+          if (mounted && !_hasShownInterstitial) {
+            _adService.showInterstitialAd();
+            _hasShownInterstitial = true;
+          }
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
 
   Widget _buildMenuCard({
     required String title,
@@ -219,82 +245,90 @@ class _HomePageState extends State<HomePage> {
         iconTheme: const IconThemeData(color: AppColors.surface),
         actions: [LanguageSelector()],
       ),
-      body: CustomScrollView(
-        slivers: [
-          SliverToBoxAdapter(child: _buildHeader(context)),
-          SliverPadding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-            sliver: SliverGrid(
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 2,
-                childAspectRatio: 1.1,
-                crossAxisSpacing: 16,
-                mainAxisSpacing: 16,
-              ),
-              delegate: SliverChildListDelegate([
-                _buildMenuCard(
-                  title: localization.land,
-                  imagePath: 'lands',
-                  categoryPath: 'lands',
-                  icon: Icons.landscape_outlined,
+      body: Column(
+        children: [
+          Expanded(
+            child: CustomScrollView(
+              slivers: [
+                SliverToBoxAdapter(child: _buildHeader(context)),
+                SliverPadding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                  sliver: SliverGrid(
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
+                      childAspectRatio: 1.1,
+                      crossAxisSpacing: 16,
+                      mainAxisSpacing: 16,
+                    ),
+                    delegate: SliverChildListDelegate([
+                      _buildMenuCard(
+                        title: localization.land,
+                        imagePath: 'lands',
+                        categoryPath: 'lands',
+                        icon: Icons.landscape_outlined,
+                      ),
+                      _buildMenuCard(
+                        title: localization.harvest,
+                        imagePath: 'harvest',
+                        categoryPath: 'harvest',
+                        icon: Icons.eco_outlined,
+                      ),
+                      _buildMenuCard(
+                        title: localization.seeds,
+                        imagePath: 'harvest',
+                        categoryPath: 'seeds_plants_and_planting_material',
+                        icon: Icons.local_florist_outlined,
+                      ),
+                      _buildMenuCard(
+                        title: localization.animals,
+                        imagePath: 'farms',
+                        categoryPath: 'animal_control',
+                        icon: Icons.pets_outlined,
+                      ),
+                      _buildMenuCard(
+                        title: localization.productions,
+                        imagePath: 'productions',
+                        categoryPath: 'processed_productions',
+                        icon: Icons.inventory_2_outlined,
+                      ),
+                      _buildMenuCard(
+                        title: localization.labour,
+                        imagePath: 'productions',
+                        categoryPath: 'service_providers',
+                        icon: Icons.engineering_outlined,
+                      ),
+                      _buildMenuCard(
+                        title: localization.vehicle,
+                        imagePath: 'vehicles',
+                        categoryPath: 'vehicles',
+                        icon: Icons.agriculture_outlined,
+                      ),
+                      _buildMenuCard(
+                        title: localization.machineries,
+                        imagePath: 'machineries',
+                        categoryPath: 'machineries',
+                        icon: Icons.precision_manufacturing_outlined,
+                      ),
+                      _buildMenuCard(
+                        title: localization.agriEquipment,
+                        imagePath: 'equipments',
+                        categoryPath: 'agricultural_equipment',
+                        icon: Icons.build_outlined,
+                      ),
+                      _buildMenuCard(
+                        title: localization.fertilizers,
+                        imagePath: 'fertilizers',
+                        categoryPath: 'fertilizer',
+                        icon: Icons.sanitizer_outlined,
+                      ),
+                    ]),
+                  ),
                 ),
-                _buildMenuCard(
-                  title: localization.harvest,
-                  imagePath: 'harvest',
-                  categoryPath: 'harvest',
-                  icon: Icons.eco_outlined,
-                ),
-                _buildMenuCard(
-                  title: localization.seeds,
-                  imagePath: 'harvest',
-                  categoryPath: 'seeds_plants_and_planting_material',
-                  icon: Icons.local_florist_outlined,
-                ),
-                _buildMenuCard(
-                  title: localization.animals,
-                  imagePath: 'farms',
-                  categoryPath: 'animal_control',
-                  icon: Icons.pets_outlined,
-                ),
-                _buildMenuCard(
-                  title: localization.productions,
-                  imagePath: 'productions',
-                  categoryPath: 'processed_productions',
-                  icon: Icons.inventory_2_outlined,
-                ),
-                _buildMenuCard(
-                  title: localization.labour,
-                  imagePath: 'productions',
-                  categoryPath: 'service_providers',
-                  icon: Icons.engineering_outlined,
-                ),
-                _buildMenuCard(
-                  title: localization.vehicle,
-                  imagePath: 'vehicles',
-                  categoryPath: 'vehicles',
-                  icon: Icons.agriculture_outlined,
-                ),
-                _buildMenuCard(
-                  title: localization.machineries,
-                  imagePath: 'machineries',
-                  categoryPath: 'machineries',
-                  icon: Icons.precision_manufacturing_outlined,
-                ),
-                _buildMenuCard(
-                  title: localization.agriEquipment,
-                  imagePath: 'equipments',
-                  categoryPath: 'agricultural_equipment',
-                  icon: Icons.build_outlined,
-                ),
-                _buildMenuCard(
-                  title: localization.fertilizers,
-                  imagePath: 'fertilizers',
-                  categoryPath: 'fertilizer',
-                  icon: Icons.sanitizer_outlined,
-                ),
-              ]),
+              ],
             ),
           ),
+          // Banner Ad at the bottom
+          const BannerAdWidget(),
         ],
       ),
     );

--- a/lib/features/items view/item_view.dart
+++ b/lib/features/items view/item_view.dart
@@ -8,6 +8,8 @@ import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:aswenna/core/services/ad_service.dart';
+import 'package:aswenna/widgets/banner_ad_widget.dart';
 
 class ItemViewPage extends StatefulWidget {
   final String? documentId;
@@ -57,6 +59,7 @@ class ItemViewPage extends StatefulWidget {
 
 class _ItemViewPageState extends State<ItemViewPage> {
   final FirestoreService _firestoreService = FirestoreService();
+  final AdService _adService = AdService();
   bool isLoading = false;
   bool isImageViewVisible = false;
   Map<String, dynamic> itemData = {};
@@ -65,11 +68,24 @@ class _ItemViewPageState extends State<ItemViewPage> {
   List<String> imageUrls = [];
   int currentImageIndex = 0;
   bool isOwner = false;
+  bool _hasShownInterstitial = false;
 
   @override
   void initState() {
     super.initState();
     _initData();
+    // Load interstitial ad for item view page
+    _adService.loadInterstitialAd(onAdLoaded: () {
+      // Show interstitial ad after a short delay when page opens
+      if (!_hasShownInterstitial && mounted) {
+        Future.delayed(const Duration(milliseconds: 800), () {
+          if (mounted && !_hasShownInterstitial) {
+            _adService.showInterstitialAd();
+            _hasShownInterstitial = true;
+          }
+        });
+      }
+    });
   }
 
   Future<void> _initData() async {
@@ -1189,6 +1205,13 @@ class _ItemViewPageState extends State<ItemViewPage> {
 
                   // 3. OWNER DETAILS SECTION (LAST)
                   _buildOwnerDetailsSection(),
+
+                  SizedBox(height: 16),
+
+                  // Banner Ad
+                  const BannerAdWidget(isLarge: true),
+
+                  SizedBox(height: 16),
                 ],
               ),
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,10 +5,12 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:aswenna/providers/locale_provider.dart';
+import 'package:aswenna/core/services/ad_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
+  await AdService.initialize();
   Provider.debugCheckInvalidValueType = null;
 
   runApp(

--- a/lib/widgets/banner_ad_widget.dart
+++ b/lib/widgets/banner_ad_widget.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+import '../core/services/ad_service.dart';
+
+class BannerAdWidget extends StatefulWidget {
+  final bool isLarge;
+
+  const BannerAdWidget({
+    Key? key,
+    this.isLarge = false,
+  }) : super(key: key);
+
+  @override
+  State<BannerAdWidget> createState() => _BannerAdWidgetState();
+}
+
+class _BannerAdWidgetState extends State<BannerAdWidget> {
+  BannerAd? _bannerAd;
+  bool _isAdLoaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAd();
+  }
+
+  void _loadAd() {
+    final adService = AdService();
+    _bannerAd = widget.isLarge
+        ? adService.createLargeBannerAd()
+        : adService.createBannerAd();
+
+    _bannerAd!.load().then((_) {
+      if (mounted) {
+        setState(() {
+          _isAdLoaded = true;
+        });
+      }
+    }).catchError((error) {
+      print('Error loading banner ad: $error');
+    });
+  }
+
+  @override
+  void dispose() {
+    _bannerAd?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isAdLoaded || _bannerAd == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      alignment: Alignment.center,
+      width: _bannerAd!.size.width.toDouble(),
+      height: _bannerAd!.size.height.toDouble(),
+      child: AdWidget(ad: _bannerAd!),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   share_plus: ^10.1.4
   cached_network_image: ^3.4.1
   url_launcher: ^6.3.1
+  google_mobile_ads: ^5.1.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
- Added google_mobile_ads dependency to pubspec.yaml
- Configured AdMob App IDs for Android and iOS (test IDs for now)
- Created reusable AdService class for managing ads
- Created BannerAdWidget component for easy ad placement
- Added interstitial ad that shows when opening home page
- Added banner ad at the bottom of home page
- Added interstitial ad that shows when opening item view page
- Added large banner ad in item view page after owner details
- Initialized Mobile Ads SDK in main.dart

Note: Currently using Google test ad IDs. Replace with actual AdMob IDs in production.