### PR TITLE
Fix deprecated API warnings in Google Mobile Ads

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
     implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.android.play:core:1.10.3")
 }
 
 flutter {


### PR DESCRIPTION
Added com.google.android.play:core:1.10.3 dependency to resolve missing classes error during release build. This fixes the R8 compilation failure caused by missing SplitCompat and related Play Core classes referenced by Flutter's embedding engine.