### PR TITLE
Fix duplicate class error in Android build

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -68,7 +68,6 @@ dependencies {
     implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
     implementation("com.google.firebase:firebase-analytics")
-    implementation("com.google.android.play:core:1.10.3")
 }
 
 flutter {


### PR DESCRIPTION
Removed com.google.android.play:core:1.10.3 dependency which was causing duplicate class conflicts with newer modular Play Core libraries (core-common:2.0.3) that are pulled in as transitive dependencies.

The old monolithic play:core library has been deprecated and replaced with modular libraries. The necessary Play Core functionality is provided by transitive dependencies.

Fixes: checkReleaseDuplicateClasses task failure