### PR TITLE
Replace deprecated Play Core library with modular feature-delivery

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
     implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.android.play:feature-delivery:2.1.0")
 }
 
 flutter {


### PR DESCRIPTION
Migrated from the deprecated monolithic play:core library to the new modular feature-delivery library to fix duplicate class errors while maintaining Flutter's split install and deferred component functionality.

Changes:
- Removed: com.google.android.play:core:1.10.3 (deprecated)
- Added: com.google.android.play:feature-delivery:2.1.0 (new modular lib)

This resolves both:
1. Duplicate class conflicts between core:1.10.3 and core-common:2.0.3
2. Missing classes needed by Flutter's PlayStoreDeferredComponentManager

The feature-delivery library provides all required classes:
- SplitCompatApplication
- SplitInstallManager
- SplitInstallManagerFactory
- And other split install related classes

Fixes: checkReleaseDuplicateClasses and minifyReleaseWithR8 failures