### PR TITLE
Fix duplicate classes by excluding core-common from play:core library

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -68,7 +68,9 @@ dependencies {
     implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
     implementation("com.google.firebase:firebase-analytics")
-    implementation("com.google.android.play:feature-delivery:2.1.0")
+    implementation("com.google.android.play:core:1.10.3") {
+        exclude(group = "com.google.android.play", module = "core-common")
+    }
 }
 
 flutter {


### PR DESCRIPTION
Changed approach to keep the deprecated play:core:1.10.3 library but exclude the conflicting core-common module to prevent duplicate class errors.

This resolves both issues:
1. Duplicate class conflicts: Excluded core-common from play:core to avoid conflicts with the newer core-common:2.0.3 transitive dependency
2. Missing Task classes: Retained play:core which provides the com.google.android.play.core.tasks.* classes needed by Flutter's PlayStoreDeferredComponentManager

The exclusion prevents duplicate classes for:
- IntentSenderForResultStarter
- LocalTestingException
- PlayCoreDialogWrapperActivity
- StateUpdatedListener

While maintaining all required functionality for Flutter's split install and deferred component features.

Fixes: checkReleaseDuplicateClasses and minifyReleaseWithR8 failures