### PR TITLE
Fix duplicate classes with global core-common exclusion

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -60,6 +60,10 @@ android {
     }
 }
 
+configurations.all {
+    exclude(group = "com.google.android.play", module = "core-common")
+}
+
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.2")
     implementation(platform("com.google.firebase:firebase-bom:32.7.1"))
@@ -68,9 +72,7 @@ dependencies {
     implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
     implementation("com.google.firebase:firebase-analytics")
-    implementation("com.google.android.play:core:1.10.3") {
-        exclude(group = "com.google.android.play", module = "core-common")
-    }
+    implementation("com.google.android.play:core:1.10.3")
 }
 
 flutter {


### PR DESCRIPTION
Added a global configuration to exclude core-common from all transitive dependencies, resolving the duplicate class conflict between play:core:1.10.3 and core-common:2.0.3.

Changes:
- Added configurations.all block to globally exclude core-common
- Kept play:core:1.10.3 which provides all required classes for Flutter
- Prevents any dependency from pulling in core-common:2.0.3

This approach ensures:
1. No duplicate classes (core-common excluded globally)
2. All Flutter functionality works (play:core:1.10.3 retained)
3. All required Play Core classes available including Tasks API

The global exclusion prevents conflicts from any transitive dependency source (credentials-play-services-auth, googleid, etc.) while maintaining full Play Core functionality.

Fixes: checkReleaseDuplicateClasses error for duplicate:
- IntentSenderForResultStarter
- LocalTestingException
- PlayCoreDialogWrapperActivity
- StateUpdatedListener