### PR TITLE
Add Play Core review library to provide tasks API for Android 14

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -68,8 +68,9 @@ dependencies {
     implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
     implementation("com.google.firebase:firebase-analytics")
-    // Android 14-compatible Play Core library for Flutter's deferred components
+    // Android 14-compatible Play Core libraries for Flutter's deferred components
     implementation("com.google.android.play:feature-delivery:2.1.0")
+    implementation("com.google.android.play:review:2.0.1")  // Provides tasks API
 }
 
 flutter {


### PR DESCRIPTION
The feature-delivery library alone doesn't include the com.google.android.play.core.tasks.* classes that Flutter's PlayStoreDeferredComponentManager requires. Adding the review library (which is Android 14-compatible) provides these missing task classes:
- OnSuccessListener
- OnFailureListener
- Task

Both feature-delivery and review libraries are part of Google's new modular Play Core architecture that's compatible with targetSdkVersion 34.