### PR TITLE
Replace review library with core-common for tasks API compatibility

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     // Android 14-compatible Play Core libraries for Flutter's deferred components
     implementation("com.google.android.play:feature-delivery:2.1.0")
-    implementation("com.google.android.play:review:2.0.1")  // Provides tasks API
+    implementation("com.google.android.play:core-common:2.0.3")  // Provides tasks API
 }
 
 flutter {


### PR DESCRIPTION
The review library doesn't provide the com.google.android.play.core.tasks.* classes that Flutter's PlayStoreDeferredComponentManager requires. Switching to core-common:2.0.3 which explicitly provides these task API classes:
- com.google.android.play.core.tasks.Task
- com.google.android.play.core.tasks.OnSuccessListener
- com.google.android.play.core.tasks.OnFailureListener

The core-common library is Android 14-compatible and works alongside feature-delivery for complete Play Core functionality.