### PR TITLE
Replace debug prints with comments and update AdMob configuration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,9 +20,6 @@
               android:resource="@style/NormalTheme"
               />
             <meta-data
-                android:name="com.google.android.gms.ads.APPLICATION_ID"
-                android:value="ca-app-pub-4314688595118324~6832711660"/>
-            <meta-data
                 android:name="com.google.android.gms.version"
                 android:value="@integer/google_play_services_version" />    
             <intent-filter>
@@ -34,10 +31,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-        <!-- AdMob App ID -->
+        <!-- AdMob App ID (Production) -->
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-3940256099942544~3347511713"/>
+            android:value="ca-app-pub-4314688595118324~6832711660"/>
     </application>
     
     <!-- Queries section - this is where the fix is needed -->

--- a/lib/features/auth/introScreen.dart
+++ b/lib/features/auth/introScreen.dart
@@ -27,7 +27,7 @@ class _IntroScreenState extends State<IntroScreen> {
         height: imageSize ?? 250.0,
         padding: EdgeInsets.all(20),
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: AppColors.accent, // Changed from white to golden accent for logo visibility
           borderRadius: BorderRadius.circular(20),
           boxShadow: [
             BoxShadow(

--- a/lib/features/auth/loadingPage.dart
+++ b/lib/features/auth/loadingPage.dart
@@ -228,7 +228,7 @@ class _LoadingPageState extends State<LoadingPage>
             height: 200,
             padding: const EdgeInsets.all(20),
             decoration: BoxDecoration(
-              color: Colors.black, // Changed to black
+              color: AppColors.accent, // Golden accent color for better logo visibility
               shape: BoxShape.circle,
               boxShadow: [
                 BoxShadow(

--- a/lib/features/auth/login.dart
+++ b/lib/features/auth/login.dart
@@ -481,14 +481,7 @@ class _LoginPageState extends State<LoginPage> {
       height: 52,
       child: OutlinedButton.icon(
         onPressed: _isLoading ? null : _handleGoogleLogin,
-        icon: Image.asset(
-          'assets/google_icon.png',
-          width: 20,
-          height: 20,
-          errorBuilder: (context, error, stackTrace) {
-            return const Icon(Icons.g_mobiledata, size: 20);
-          },
-        ),
+        icon: Icon(Icons.g_mobiledata, color: AppColors.accent, size: 24),
         label: const Text(
           'Sign in with Google',
           style: TextStyle(

--- a/lib/features/items add/itemsAdd.dart
+++ b/lib/features/items add/itemsAdd.dart
@@ -831,7 +831,7 @@ class _ItemsAddPageState extends State<ItemsAddPage> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    print(widget.paths);
+    // Debug: paths logged
     return Scaffold(
       backgroundColor: AppColors.background.withValues(alpha: 0.5),
       appBar: AppBar(

--- a/lib/features/items view/item_view.dart
+++ b/lib/features/items view/item_view.dart
@@ -117,7 +117,7 @@ class _ItemViewPageState extends State<ItemViewPage> {
       if (docSnap != null && docSnap.exists) {
         setState(() {
           itemData = docSnap.data() as Map<String, dynamic>;
-          print(itemData);
+          // Item data loaded
           isOwner = itemData['userId'] == _firestoreService.currentUserId;
           _extractImageUrls();
         });

--- a/lib/screens/item_list_screen.dart
+++ b/lib/screens/item_list_screen.dart
@@ -298,7 +298,7 @@ class _ItemListScreenState extends State<ItemListScreen>
               }
             });
           } catch (e) {
-            print("Error parsing filter data: $e");
+            // Error parsing filter data
             _showErrorSnackbar('Error applying filters');
           }
         },
@@ -358,7 +358,7 @@ class _ItemListScreenState extends State<ItemListScreen>
   @override
   Widget build(BuildContext context) {
     final localization = AppLocalizations.of(context)!;
-    print(widget.parentPath);
+    // Debug: parentPath logged
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -1317,21 +1317,21 @@ class _ItemListScreenState extends State<ItemListScreen>
 
   Widget _buildSafeNetworkImage(String imageUrl) {
     // Log the image URL for debugging
-    print('Loading image: $imageUrl');
+    // Loading image from URL
 
     // Check if URL is valid
     bool isValidUrl = Uri.tryParse(imageUrl)?.hasAbsolutePath ?? false;
     if (!isValidUrl) {
-      print('Invalid image URL format: $imageUrl');
+      // Invalid image URL format
       return _buildImageError();
     }
 
     // Handle different URL protocols
     if (!imageUrl.startsWith('http://') && !imageUrl.startsWith('https://')) {
-      print('URL needs http/https protocol: $imageUrl');
+      // URL needs http/https protocol
       // Try adding https if missing
       imageUrl = 'https://${imageUrl.replaceAll(RegExp(r'^(\/\/|:\/\/)'), '')}';
-      print('Modified URL: $imageUrl');
+      // Modified URL to include https
     }
 
     try {

--- a/lib/widgets/filterBottomSheet.dart
+++ b/lib/widgets/filterBottomSheet.dart
@@ -980,7 +980,7 @@ class _FilterBottomSheetState extends State<FilterBottomSheet> {
 
           // Convert to JSON string to pass back to the parent widget
           final jsonStr = jsonEncode(filterData.toJson());
-          print("Filter Data: $jsonStr");
+          // Debug: Filter Data logged
 
           widget.onFilterChanged(jsonStr);
           Navigator.pop(context);

--- a/lib/widgets/sellinPage.dart
+++ b/lib/widgets/sellinPage.dart
@@ -83,9 +83,7 @@ class _CustomSellingPageState extends State<CustomSellingPage>
       vsync: this,
     );
     _fadeController.forward();
-    print(
-      "Selling Page: Main Name: ${widget.mainNameE} firstName: ${widget.firstLNameE} secondLName: ${widget.secondLNameE} tabName: ${widget.tabNameE}",
-    );
+    // Debug: selling page data logged
   }
 
   @override

--- a/lib/widgets/tabbar.dart
+++ b/lib/widgets/tabbar.dart
@@ -24,7 +24,7 @@ class CustomTabBar extends StatelessWidget {
   }
 
   PreferredSizeWidget _buildAppBar(BuildContext context) {
-    print("In the tab bar: tabnames: ${tabNames},title: $title");
+    // Debug: tab bar data logged
     return AppBar(
       elevation: 0,
       backgroundColor: AppColors.primary,


### PR DESCRIPTION
## Summary
This PR removes debug print statements throughout the codebase and replaces them with inline comments, while also updating the AdMob application ID configuration in the Android manifest to use the production app ID.

## Key Changes

### Debug Statement Cleanup
- Replaced all `print()` statements with descriptive inline comments across multiple files:
  - `itemsAdd.dart`: Removed widget.paths debug log
  - `item_view.dart`: Removed itemData debug log
  - `item_list_screen.dart`: Removed parentPath, image URL, and filter data debug logs
  - `filterBottomSheet.dart`: Removed filter data JSON debug log
  - `sellinPage.dart`: Removed selling page initialization debug log
  - `tabbar.dart`: Removed tab bar data debug log

### AdMob Configuration Update
- Moved AdMob APPLICATION_ID meta-data from activity level to application level in `AndroidManifest.xml`
- Updated the AdMob App ID from test ID (`ca-app-pub-3940256099942544~3347511713`) to production ID (`ca-app-pub-4314688595118324~6832711660`)
- Added clarifying comment "(Production)" to indicate this is the live AdMob configuration

### UI Color Updates
- Changed logo container background color in `introScreen.dart` from white to `AppColors.accent` for improved visibility
- Changed loading page logo container background color in `loadingPage.dart` from black to `AppColors.accent` for consistency
- Simplified Google login button icon in `login.dart` to use Material icon instead of asset image with fallback

## Implementation Details
- All debug prints were replaced with comments that describe what was being logged, maintaining code clarity for future debugging
- The AdMob configuration change ensures the app uses the correct production app ID for ad serving
- UI color changes improve visual consistency by using the app's accent color scheme

https://claude.ai/code/session_012goKg184VWzu83aHj1obpY