### PR TITLE
Fix APK installation package conflict error by adding debug suffix

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -48,6 +48,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+            isDebuggable = true
+        }
         release {
             signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true


### PR DESCRIPTION
Added debug build type with applicationIdSuffix ".debug" to allow debug and release APKs to coexist on the same device without signing conflicts. This resolves the "App not installed as package conflicts with an existing package" error.

Changes:
- Debug builds now use com.lumoraventures.aswenna.debug
- Release builds continue using com.lumoraventures.aswenna
- Users can install both versions simultaneously

https://claude.ai/code/session_01Sq25XkdD3HntTtiV2eFx9b